### PR TITLE
Fix: Improve error logging in ViewModeProvider

### DIFF
--- a/components/providers/view-mode-provider.tsx
+++ b/components/providers/view-mode-provider.tsx
@@ -38,12 +38,20 @@ export function ViewModeProvider({ children }: { children: React.ReactNode }) {
           .single()
 
         if (error) {
-          console.error("Errore nel caricamento della modalità di visualizzazione:", error)
+          if (error && Object.keys(error).length > 0) {
+            console.error("Errore nel caricamento della modalità di visualizzazione:", JSON.stringify(error, null, 2));
+          } else {
+            console.error("Errore nel caricamento della modalità di visualizzazione: Errore sconosciuto o vuoto.");
+          }
         } else if (profile?.view_mode) {
           setViewModeState(profile.view_mode as ViewMode)
         }
       } catch (error) {
-        console.error("Errore nel caricamento della modalità di visualizzazione:", error)
+        if (error && Object.keys(error).length > 0) {
+          console.error("Errore nel caricamento della modalità di visualizzazione:", JSON.stringify(error, null, 2));
+        } else {
+          console.error("Errore nel caricamento della modalità di visualizzazione: Errore sconosciuto o vuoto.");
+        }
       } finally {
         setIsLoading(false)
       }


### PR DESCRIPTION
I've updated the console.error calls in the `loadViewMode` function within `ViewModeProvider.tsx` to provide you with more detailed error messages. This includes using `JSON.stringify` for error objects and adding a default message for null or undefined errors, which should aid in debugging potential issues with loading the view mode.